### PR TITLE
feat: add custom_prompt_path option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   action:
     type: string
     required: false
-    description: 'The action to run, currently can be "review"'
+    description: 'The action to run, currently can be only "review"'
     default: 'review'
   debug:
     type: boolean
@@ -39,9 +39,8 @@ inputs:
       > $description.
 
       Next, I will given you a series of patches, each of them consists of a filename and a diff
-      snippet, and you need to do a brief code review for every message, and tell me any bug risk
-      and improvement suggestion. If the patch is looks good and acceptable, please reply "LGTM!"
-      with a short comment with 30 words.
+      snippet, and you need to do a brief code review for every message, and tell me improvement suggestion.
+      If the patch is looks good and acceptable, please reply "LGTM!" with a short comment.
 
       You answer should be concise. Don't include the diff in your comment, and markdown format is
       preferred. Reply "OK" to confirm.
@@ -55,6 +54,10 @@ inputs:
       ```diff
       $patch
       ```
+  custom_prompt_path:
+    type: string
+    required: false
+    description: 'A custom prompt sourced from a file'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -41,6 +41,7 @@ export class Bot {
   public chat = async (action: string, message: string, initial = false) => {
     console.time(`chatgpt ${action} ${message.length} tokens cost`)
     let response = null
+    core.info(`message: ${message}`)
     try {
       response = await this.chat_(action, message, initial)
     } catch (e: any) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function run(): Promise<void> {
   const prompts: Prompts = new Prompts(
     core.getInput('review_beginning'),
     core.getInput('review_patch'),
+    core.getInput('custom_prompt_path'),
   )
 
   // initialize chatgpt bot

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,16 +1,20 @@
+import fs from 'fs/promises';
 import * as core from '@actions/core'
 import {minimatch} from 'minimatch'
 
 export class Prompts {
   public review_beginning: string
   public review_patch: string
+  public custom_prompt_path: string
 
   constructor(
     review_beginning: string = '',
     review_patch: string = '',
+    custom_prompt_path: string = '',
   ) {
     this.review_beginning = review_beginning
     this.review_patch = review_patch
+    this.custom_prompt_path = custom_prompt_path
   }
 
   public render_review_beginning(inputs: Inputs): string {
@@ -21,6 +25,16 @@ export class Prompts {
     return inputs.render(this.review_patch)
   }
 
+  public async render_custom_prompt(inputs: Inputs): Promise<string> {
+    let data;
+    try {
+      data = await fs.readFile(this.custom_prompt_path, 'utf-8');
+    } catch (error) {
+      console.error('Error:', error);
+    }
+    // load file content, then render
+    return inputs.render(data ?? '');
+  }
 }
 
 export class Inputs {

--- a/src/review.ts
+++ b/src/review.ts
@@ -95,9 +95,17 @@ export const codeReview = async (
     core.info(`Reviewing ${filename}:${line} with chatgpt ...`)
     inputs.filename = filename
     inputs.patch = patch
+    // if prompts.custom_prompt_path is set, use it
+    // otherwise fall back to `render_review_patch`
+    let message: string
+    if (prompts.custom_prompt_path) {
+      message = await prompts.render_custom_prompt(inputs)
+    } else {
+      message = prompts.render_review_patch(inputs)
+    }
     const response = await bot.chat(
       'review',
-      prompts.render_review_patch(inputs)
+      message
     )
     if (!response) {
       core.info('review: nothing obtained from chatgpt')


### PR DESCRIPTION
This allows to specify a file which includes a custom prompt. All known variables can be used; like $filename and $patch